### PR TITLE
Remove unsuitable property from package object

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -176,6 +176,8 @@ class Generator extends Base {
   }
 
   writing() {
+    const removeProps = ['env', 'resolved', 'namespace', 'argv']
+    removeProps.forEach( (e) => delete this.package[e] )
     this.fs.writeJSON(this.destinationPath('package.json'), this.package)
   }
 }


### PR DESCRIPTION
### Problems
I tried `npm init` using `generator-npm-init`. But `package.json` was generated that has unsuitable properties. They are `env`, `resolved`, `namespace`, `argv`.

Maybe, these properties are using for the `yeoman/generator-generator`.

### Cause
Already, `this.options` have these properties at [line 10](https://github.com/ringohub/generator-npm-init/blob/master/app/index.js#L10).
And at [line 56](https://github.com/caseyWebb/generator-npm-init/blob/master/app/index.js#L56), these properties are merged into the package object.

### Action
Remove unsuitable property from package object when writing package object.

But, I think this action is symptomatic treatment. If new property is added by generator updating that we required fixing this issue again.